### PR TITLE
Return `HTTP 200 OK` in the response for declared and known endpoints.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.9
+# Customers API Lite microservice prototype (V port). Version 0.0.10
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.9
+# Customers API Lite microservice prototype (V port). Version 0.0.10
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/README.md
+++ b/README.md
@@ -129,23 +129,24 @@ $ make all  # <== Building the daemon.
 
 ```
 $ ./bin/api-lited; echo $?
-[2025-02-19][19:35:10] [DEBUG] [Customers API Lite]
+[2025-02-21][11:05:10] [DEBUG] [Customers API Lite]
 [veb] Running app on http://localhost:8765/
+[2025-02-21][11:10:05] [DEBUG] [true]
 ```
 
 Thus, from now on it is already possible to send HTTP requests to the running daemon:
 
 ```
-$ curl -v http://localhost:8765
+$ curl -v http://localhost:8765/v1/customers
 ...
-> GET / HTTP/1.1
+> GET /v1/customers HTTP/1.1
 ...
-< HTTP/1.1 404 Not Found
+< HTTP/1.1 200 OK
 < Content-Type: text/plain
-< Content-Length: 13
+< Content-Length: 6
 < Server: veb
 ...
-404 Not Found
+[true]
 ```
 
 ---

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.9
+-- Customers API Lite microservice prototype (V port). Version 0.0.10
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.9
+-- Customers API Lite microservice prototype (V port). Version 0.0.10
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.9
+-- Customers API Lite microservice prototype (V port). Version 0.0.10
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.9
+-- Customers API Lite microservice prototype (V port). Version 0.0.10
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/etc/settings.conf
+++ b/etc/settings.conf
@@ -1,7 +1,7 @@
 #
 # etc/settings.conf
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.9
+# Customers API Lite microservice prototype (V port). Version 0.0.10
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-controller.v
+++ b/src/api-lite-controller.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-controller.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.9
+ * Customers API Lite microservice prototype (V port). Version 0.0.10
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-controller.v
+++ b/src/api-lite-controller.v
@@ -14,26 +14,13 @@
 
 module controller
 
-import veb
+import log
 
 import helper as h
 
-// Defining an alias for the `CustomersApiLiteApp` struct.
-type App = h.CustomersApiLiteApp
-
-// list_customers The `GET /v1/customers` endpoint.
-//
-// Retrieves from the database and lists all customer profiles.
-//
-// @returns The `Result` dummy struct with the `200 OK` HTTP status code
-//          and the response body in JSON representation, containing a list
-//          of all customer profiles.
-//          May return client or server error depending on incoming request.
-@['/v1/customers']
-fn (mut app App) list_customers(mut ctx h.RequestContext) veb.Result {
-    h.dbg_(app.dbg, mut app.l, h.o_bracket + '${app.dbg}' + h.c_bracket)
-
-    return ctx.text(h.o_bracket + '${app.dbg}' + h.c_bracket)
+// list_customers_ Helper function for the `list_customers()` endpoint.
+pub fn list_customers_(dbg bool, mut l log.Log) {
+    h.dbg_(dbg, mut l, h.o_bracket + '${dbg}' + h.c_bracket)
 }
 
 // vim:set nu et ts=4 sw=4:

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-core.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.9
+ * Customers API Lite microservice prototype (V port). Version 0.0.10
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -14,9 +14,8 @@
 
 module helper
 
-import log
-import veb
 import toml
+import log
 
 import vseryakov.syslog as s
 
@@ -40,19 +39,6 @@ pub const log_enabled_ = 'logger.debug.enabled'
 pub const log_dir_ = './log_/'
 pub const logfile_ = 'customers-api-lite.log'
 pub const logtime_ = '[YYYY-MM-DD][HH:mm:ss]'
-
-// CustomersApiLiteApp The struct containing data that are shared between
-// different routes.
-pub struct CustomersApiLiteApp {
-pub mut:
-    dbg bool
-    l   log.Log
-}
-
-// RequestContext The struct containing data that are specific to each request.
-pub struct RequestContext {
-    veb.Context
-}
 
 // get_settings_ Helper function. Used to get the daemon settings.
 pub fn get_settings_() toml.Doc {

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-helper.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.9
+ * Customers API Lite microservice prototype (V port). Version 0.0.10
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,7 @@
 Module {
     name:         'api-lited'
     description:  'A daemon written in V (vlang/veb), designed and intended to be run as a microservice, implementing a special Customers API prototype with a smart yet simplified data scheme.'
-    version:      '0.0.9'
+    version:      '0.0.10'
     license:      'MIT'
     dependencies: []
 }


### PR DESCRIPTION
- Returning `HTTP 200 OK` in the response for _declared and known_ endpoints.
- **Bugfix:** Mandatory web app structs need to be declared in the main web app module.
- **Bugfix:** Endpoints need to be declared in the main web app module.
- Bumping version number to **0.0.10**.