### PR TITLE
Respond to a client with JSON in the response body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ $ make all  # <== Building the daemon.
 
 ```
 $ ./bin/api-lited; echo $?
-[2025-02-21][18:20:00] [DEBUG] [Customers API Lite]
-[veb] Running app on http://localhost:8765/
-[2025-02-21][18:20:40] [DEBUG] [true]
+[2025-02-22][10:00:40] [INFO ] Server started on port 8765
+[2025-02-22][10:00:40] [DEBUG] [Customers API Lite]
+[2025-02-22][10:00:50] [DEBUG] [true]
 ```
 
 Thus, from now on it is already possible to send HTTP requests to the running daemon:

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ $ make all  # <== Building the daemon.
 
 ```
 $ ./bin/api-lited; echo $?
-[2025-02-21][11:05:10] [DEBUG] [Customers API Lite]
+[2025-02-21][18:20:00] [DEBUG] [Customers API Lite]
 [veb] Running app on http://localhost:8765/
-[2025-02-21][11:10:05] [DEBUG] [true]
+[2025-02-21][18:20:40] [DEBUG] [true]
 ```
 
 Thus, from now on it is already possible to send HTTP requests to the running daemon:
@@ -142,11 +142,11 @@ $ curl -v http://localhost:8765/v1/customers
 > GET /v1/customers HTTP/1.1
 ...
 < HTTP/1.1 200 OK
-< Content-Type: text/plain
-< Content-Length: 6
+< Content-Type: application/json
+< Content-Length: 34
 < Server: veb
 ...
-[true]
+{"logging":"debug","enabled":true}
 ```
 
 ---

--- a/src/api-lite-controller.v
+++ b/src/api-lite-controller.v
@@ -18,6 +18,21 @@ import log
 
 import helper as h
 
+struct Logger_ {
+    logging string
+    enabled bool
+}
+
+// common_ctrl_hlpr_ Common controller helper function.
+pub fn common_ctrl_hlpr_(dbg bool) &Logger_ {
+    logger := &Logger_{
+        logging: 'debug'
+        enabled: dbg
+    }
+
+    return logger
+}
+
 // list_customers_ Helper function for the `list_customers()` endpoint.
 pub fn list_customers_(dbg bool, mut l log.Log) {
     h.dbg_(dbg, mut l, h.o_bracket + '${dbg}' + h.c_bracket)

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -23,8 +23,8 @@ import vseryakov.syslog as s
 import helper     as h
 import controller as c
 
-// CustomersApiLiteApp The struct containing data that are shared between
-// different routes.
+// CustomersApiLiteApp The main web app struct containing arbitrary data
+// that are accessible by all endpoints and shared between different routes.
 struct CustomersApiLiteApp {
     dbg bool
 mut:
@@ -32,6 +32,7 @@ mut:
 }
 
 // RequestContext The struct containing data that are specific to each request.
+// It also holds a standard HTTP request/response pair.
 struct RequestContext {
     veb.Context
 }
@@ -102,7 +103,9 @@ fn (mut app CustomersApiLiteApp) list_customers(mut ctx RequestContext)
 
     c.list_customers_(app.dbg, mut app.l)
 
-    return ctx.text(h.o_bracket + '${app.dbg}' + h.c_bracket)
+    logger := c.common_ctrl_hlpr_(app.dbg)
+
+    return ctx.json(logger)
 }
 
 // vim:set nu et ts=4 sw=4:

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -68,9 +68,12 @@ fn main() {
 
     // Opening the system logger.
     // Calling <syslog.h> openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);
-    s.open(h.empty_string, s.log_cons | s.log_pid, s.log_daemon)
+    s.open(os.args[0], s.log_cons | s.log_pid, s.log_daemon)
 
 //  if dbg { l.set_level(.debug) }
+
+    l.info(h.msg_server_started + '${server_port}')
+    s.info(h.msg_server_started + '${server_port}')
 
     h.dbg_(dbg, mut l, h.o_bracket + daemon_name + h.c_bracket)
 
@@ -81,13 +84,10 @@ fn main() {
 
     // Trying to start up the inbuilt web server.
     veb.run_at[CustomersApiLiteApp, RequestContext](mut app, port: server_port,
-        show_startup_message: false) or { panic(err) }
-
-    l.close()
-
-    // Closing the system logger.
-    // Calling <syslog.h> closelog();
-    s.close()
+        show_startup_message: false) or {
+            h.cleanup_(mut l)
+            panic(err)
+        }
 }
 
 // list_customers The `GET /v1/customers` endpoint.

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -25,7 +25,7 @@ import controller as c
 
 // CustomersApiLiteApp The main web app struct containing arbitrary data
 // that are accessible by all endpoints and shared between different routes.
-struct CustomersApiLiteApp {
+pub struct CustomersApiLiteApp {
     dbg bool
 mut:
     l   log.Log
@@ -33,7 +33,7 @@ mut:
 
 // RequestContext The struct containing data that are specific to each request.
 // It also holds a standard HTTP request/response pair.
-struct RequestContext {
+pub struct RequestContext {
     veb.Context
 }
 
@@ -46,7 +46,7 @@ fn main() {
 
     daemon_name := settings.value(h.daemon_name_).string()
 
-    // Getting the port number used to run the bundled web server.
+    // Getting the port number used to run the inbuilt web server.
     server_port := settings.value(h.server_port_).int()
 
     // Identifying whether debug logging is enabled.
@@ -79,8 +79,9 @@ fn main() {
         l:   l
     }
 
-    // Starting up the bundled web server.
-    veb.run[CustomersApiLiteApp, RequestContext](mut app, server_port)
+    // Trying to start up the inbuilt web server.
+    veb.run_at[CustomersApiLiteApp, RequestContext](mut app, port: server_port,
+        show_startup_message: false) or { panic(err) }
 
     l.close()
 
@@ -98,7 +99,7 @@ fn main() {
 //          of all customer profiles.
 //          May return client or server error depending on incoming request.
 @['/v1/customers']
-fn (mut app CustomersApiLiteApp) list_customers(mut ctx RequestContext)
+pub fn (mut app CustomersApiLiteApp) list_customers(mut ctx RequestContext)
     veb.Result {
 
     c.list_customers_(app.dbg, mut app.l)

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -25,15 +25,15 @@ pub const o_bracket    = '['
 pub const c_bracket    = ']'
 
 // settings_ The path and filename of the daemon settings.
-const settings_ = './etc/settings.conf'
+pub const settings_ = './etc/settings.conf'
 
-// Daemon settings key for the microservice daemon name.
+// daemon_name_ Daemon settings key for the microservice daemon name.
 pub const daemon_name_ = 'daemon.name'
 
-// Daemon settings key for the server port number.
+// server_port_ Daemon settings key for the server port number.
 pub const server_port_ = 'server.port'
 
-// Daemon settings key for the debug logging enabler.
+// log_enabled_ Daemon settings key for the debug logging enabler.
 pub const log_enabled_ = 'logger.debug.enabled'
 
 pub const log_dir_ = './log_/'

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -24,6 +24,10 @@ pub const empty_string =  ''
 pub const o_bracket    = '['
 pub const c_bracket    = ']'
 
+// Common notification messages.
+pub const msg_server_started = "Server started on port "
+pub const msg_server_stopped = "Server stopped"
+
 // settings_ The path and filename of the daemon settings.
 pub const settings_ = './etc/settings.conf'
 
@@ -51,6 +55,18 @@ pub fn dbg_(dbg bool, mut l log.Log, message string) {
         l.debug(message);
         s.debug(message);
     }
+}
+
+// cleanup_ Helper function. Makes final cleanups, closes streams, etc.
+pub fn cleanup_(mut l log.Log) {
+    l.info(msg_server_stopped)
+    s.info(msg_server_stopped)
+
+    l.close()
+
+    // Closing the system logger.
+    // Calling <syslog.h> closelog();
+    s.close()
 }
 
 // vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Printing the **daemon executable** in syslog and a **custom startup banner** in all logs.
- Responding to a client with **JSON** in the response body.
- Suppressing emitting the standard startup banner of the inbuilt web server.
- Adding constants: common notification messages.
- Adding the helper `cleanup_()` function.
- Replacing the web server standard startup banner with a custom one.
- Declaring the common controller helper function along with its auxiliary struct.