### PR TITLE
Check whether the port number used to run the inbuilt web server is valid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,7 @@ $ make all  # <== Building the daemon.
 
 ```
 $ ./bin/api-lited; echo $?
-[2025-02-22][10:00:40] [INFO ] Server started on port 8765
-[2025-02-22][10:00:40] [DEBUG] [Customers API Lite]
-[2025-02-22][10:00:50] [DEBUG] [true]
+...
 ```
 
 Thus, from now on it is already possible to send HTTP requests to the running daemon:

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -46,9 +46,6 @@ fn main() {
 
     daemon_name := settings.value(h.daemon_name_).string()
 
-    // Getting the port number used to run the inbuilt web server.
-    server_port := settings.value(h.server_port_).int()
-
     // Identifying whether debug logging is enabled.
     dbg := settings.value(h.log_enabled_).bool()
 
@@ -66,11 +63,12 @@ fn main() {
     l.set_full_logpath(h.log_dir_ + h.logfile_)
     l.log_to_console_too()
 
+    // Getting the port number used to run the inbuilt web server.
+    server_port := h.get_server_port_(settings, mut l)
+
     // Opening the system logger.
     // Calling <syslog.h> openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);
     s.open(os.base(os.args[0]), s.log_cons | s.log_pid, s.log_daemon)
-
-//  if dbg { l.set_level(.debug) }
 
     l.info(h.msg_server_started + '${server_port}')
     s.info(h.msg_server_started + '${server_port}')

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -66,6 +66,7 @@ pub fn get_settings_() toml.Doc {
 // the inbuilt web server, from daemon settings.
 //
 // @param `settings` The daemon settings as a `toml.Doc` struct.
+// @param `l`        The main logger of the daemon.
 //
 // @returns The port number on which the server has to be run.
 pub fn get_server_port_(settings toml.Doc, mut l log.Log) int {

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -16,6 +16,7 @@ module helper
 
 import toml
 import log
+import veb
 
 import vseryakov.syslog as s
 
@@ -24,12 +25,24 @@ pub const empty_string =  ''
 pub const o_bracket    = '['
 pub const c_bracket    = ']'
 
+// Common error messages.
+const err_port_valid_must_be_positive_int
+    = 'Valid server port must be a positive integer value, '
+    + 'in the range 1024 .. 49151. The default value of 8080 '
+    + 'will be used instead.'
+
 // Common notification messages.
-pub const msg_server_started = "Server started on port "
-pub const msg_server_stopped = "Server stopped"
+pub const msg_server_started = 'Server started on port '
+pub const msg_server_stopped = 'Server stopped'
 
 // settings_ The path and filename of the daemon settings.
 pub const settings_ = './etc/settings.conf'
+
+// min_port The minimum port number allowed.
+pub const min_port = 1024
+
+// max_port The maximum port number allowed.
+pub const max_port = 49151
 
 // daemon_name_ Daemon settings key for the microservice daemon name.
 pub const daemon_name_ = 'daemon.name'
@@ -47,6 +60,30 @@ pub const logtime_ = '[YYYY-MM-DD][HH:mm:ss]'
 // get_settings_ Helper function. Used to get the daemon settings.
 pub fn get_settings_() toml.Doc {
     return toml.parse_file(settings_) or { panic(err) }
+}
+
+// get_server_port_ Retrieves the port number used to run
+// the inbuilt web server, from daemon settings.
+//
+// @param `settings` The daemon settings as a `toml.Doc` struct.
+//
+// @returns The port number on which the server has to be run.
+pub fn get_server_port_(settings toml.Doc, mut l log.Log) int {
+    server_port := settings.value(server_port_).int()
+
+    if server_port != 0 {
+        if (server_port >= min_port) && (server_port <= max_port) {
+            return server_port
+        } else {
+            l.error(err_port_valid_must_be_positive_int)
+
+            return veb.default_port
+        }
+    } else {
+        l.error(err_port_valid_must_be_positive_int)
+
+        return veb.default_port
+    }
 }
 
 // dbg_ Helper func. Used to log messages for debugging aims in a free form.


### PR DESCRIPTION
- Adding a function that retrieves the **port number** used to run the inbuilt web server, from daemon settings, making a validation of the **port number**.
- Getting the **port number** used to run the inbuilt web server by calling a dedicated function that retrieves the **port number** from daemon settings.
- Adding constants: common error messages and the _minimum_ and the _maximum_ port numbers allowed.