### PR TITLE
Handle properly server startup errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.11
+# Customers API Lite microservice prototype (V port). Version 0.0.12
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.11
+# Customers API Lite microservice prototype (V port). Version 0.0.12
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.11
+-- Customers API Lite microservice prototype (V port). Version 0.0.12
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.11
+-- Customers API Lite microservice prototype (V port). Version 0.0.12
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.11
+-- Customers API Lite microservice prototype (V port). Version 0.0.12
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.11
+-- Customers API Lite microservice prototype (V port). Version 0.0.12
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/etc/settings.conf
+++ b/etc/settings.conf
@@ -1,7 +1,7 @@
 #
 # etc/settings.conf
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.11
+# Customers API Lite microservice prototype (V port). Version 0.0.12
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-controller.v
+++ b/src/api-lite-controller.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-controller.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.11
+ * Customers API Lite microservice prototype (V port). Version 0.0.12
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -75,6 +75,10 @@ fn main() {
 
     h.dbg_(dbg, mut l, h.o_bracket + daemon_name + h.c_bracket)
 
+    // Attaching Unix signal handlers to ensure daemon clean shutdown.
+    os.signal_opt(.int,  h.cleanup__)! // <== SIGINT
+    os.signal_opt(.term, h.cleanup__)! // <== SIGTERM
+
     mut app := &CustomersApiLiteApp{
         dbg: dbg
         l:   l

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -88,7 +88,14 @@ fn main() {
     veb.run_at[CustomersApiLiteApp, RequestContext](mut app, port: server_port,
         show_startup_message: false) or {
             h.cleanup_(mut l)
-            panic(err)
+
+            if err.msg().match_glob(h.err_eaddrinuse_glob) {
+                l.error(h.err_cannot_start_server + h.err_addr_already_in_use)
+            } else {
+                l.error(h.err_cannot_start_server + h.err_serv_unknown_reason)
+            }
+
+            exit(h.exit_failure)
         }
 }
 

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-core.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.11
+ * Customers API Lite microservice prototype (V port). Version 0.0.12
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -17,10 +17,13 @@ module helper
 import toml
 import log
 import veb
+import os
 
 import vseryakov.syslog as s
 
 // Helper constants.
+    const exit_failure =   1 //    Failing exit status.
+    const exit_success =   0 // Successful exit status.
 pub const empty_string =  ''
 pub const o_bracket    = '['
 pub const c_bracket    = ']'
@@ -105,6 +108,20 @@ pub fn cleanup_(mut l log.Log) {
     // Closing the system logger.
     // Calling <syslog.h> closelog();
     s.close()
+}
+
+// cleanup__ Helper function. Does same things as the `cleanup_(mut l log.Log)`
+// function, but gets called when an appropriate POSIX signal is received.
+// There are two signals supported: `SIGINT` (<Ctrl-C>) and `SIGTERM`.
+pub fn cleanup__(signal os.Signal) {
+    eprintln(msg_server_stopped)
+      s.info(msg_server_stopped)
+
+    // Closing the system logger.
+    // Calling <syslog.h> closelog();
+    s.close()
+
+    exit(exit_success)
 }
 
 // vim:set nu et ts=4 sw=4:

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -22,9 +22,8 @@ import os
 import vseryakov.syslog as s
 
 // Helper constants.
-    const exit_failure =   1 //    Failing exit status.
-    const exit_success =   0 // Successful exit status.
-pub const empty_string =  ''
+pub const exit_failure =   1 //    Failing exit status.
+pub const exit_success =   0 // Successful exit status.
 pub const o_bracket    = '['
 pub const c_bracket    = ']'
 
@@ -33,6 +32,13 @@ const err_port_valid_must_be_positive_int
     = 'Valid server port must be a positive integer value, '
     + 'in the range 1024 .. 49151. The default value of 8080 '
     + 'will be used instead.'
+pub const err_cannot_start_server
+    = 'FATAL: Cannot start server '
+pub const err_addr_already_in_use
+    = 'due to address requested already in use. Quitting...'
+pub const err_serv_unknown_reason
+    = 'for an unknown reason. Quitting...'
+pub const err_eaddrinuse_glob = '*98*'
 
 // Common notification messages.
 pub const msg_server_started = 'Server started on port '

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-helper.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.11
+ * Customers API Lite microservice prototype (V port). Version 0.0.12
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,7 @@
 Module {
     name:         'api-lited'
     description:  'A daemon written in V (vlang/veb), designed and intended to be run as a microservice, implementing a special Customers API prototype with a smart yet simplified data scheme.'
-    version:      '0.0.11'
+    version:      '0.0.12'
     license:      'MIT'
     dependencies: []
 }


### PR DESCRIPTION
- Handling properly errors when the _port requested already in use_ (during server startup).
- Introducing a helper function `cleanup__()` that gets called when an appropriate **POSIX** signal is received.
- Attaching **Unix signal handlers** to ensure daemon clean shutdown.
- Adding constants: common error messages.
- Bumping version number to **0.0.12**.