### PR TITLE
Handle properly HTTP PUT, GET, HEAD methods only.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.12
+# Customers API Lite microservice prototype (V port). Version 0.0.20
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.12
+# Customers API Lite microservice prototype (V port). Version 0.0.20
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/data/sql/00-create-db-create-and-populate-table-tmp.sql
+++ b/data/sql/00-create-db-create-and-populate-table-tmp.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/00-create-db-create-and-populate-table-tmp.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.12
+-- Customers API Lite microservice prototype (V port). Version 0.0.20
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/01-create-and-populate-table-customers.sql
+++ b/data/sql/01-create-and-populate-table-customers.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/01-create-and-populate-table-customers.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.12
+-- Customers API Lite microservice prototype (V port). Version 0.0.20
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/02-create-and-populate-table-contact_phones.sql
+++ b/data/sql/02-create-and-populate-table-contact_phones.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/02-create-and-populate-table-contact_phones.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.12
+-- Customers API Lite microservice prototype (V port). Version 0.0.20
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/data/sql/03-create-and-populate-table-contact_emails.sql
+++ b/data/sql/03-create-and-populate-table-contact_emails.sql
@@ -1,7 +1,7 @@
 --
 -- data/sql/03-create-and-populate-table-contact_emails.sql
 -- ============================================================================
--- Customers API Lite microservice prototype (V port). Version 0.0.12
+-- Customers API Lite microservice prototype (V port). Version 0.0.20
 -- ============================================================================
 -- A daemon written in V (vlang/veb), designed and intended to be run
 -- as a microservice, implementing a special Customers API prototype

--- a/etc/settings.conf
+++ b/etc/settings.conf
@@ -1,7 +1,7 @@
 #
 # etc/settings.conf
 # =============================================================================
-# Customers API Lite microservice prototype (V port). Version 0.0.12
+# Customers API Lite microservice prototype (V port). Version 0.0.20
 # =============================================================================
 # A daemon written in V (vlang/veb), designed and intended to be run
 # as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-controller.v
+++ b/src/api-lite-controller.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-controller.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.12
+ * Customers API Lite microservice prototype (V port). Version 0.0.20
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -149,6 +149,9 @@ pub fn (mut app CustomersApiLiteApp) add_list_customers(mut ctx RequestContext)
     } else if (method == .get) || (method == .head) {
         c.list_customers_(app.dbg, mut app.l)
     } else {
+        // Methods POST, PATCH, DELETE, OPTIONS, and TRACE go here.
+        // For any other method veb will automatically respond
+        // with the HTTP 404 Not Found status code.
         ctx.res.header.add(.allow, h.hdr_allow_1)
         ctx.res.set_status(.method_not_allowed) //< HTTP 405 Method Not Allowed
 
@@ -182,7 +185,8 @@ pub fn (mut app CustomersApiLiteApp) add_list_customers(mut ctx RequestContext)
 //          body in JSON representation, containing details of a newly created
 //          customer contact (phone or email).
 //          May return client or server error depending on incoming request.
-@['/v1/customers/contacts'; put; head; get; post; patch; delete; options; trace]
+@['/v1/customers/contacts'; put; head;
+    get; post; patch; delete; options; trace]
 pub fn (mut app CustomersApiLiteApp) add_contact(mut ctx RequestContext)
     veb.Result {
 
@@ -203,6 +207,7 @@ pub fn (mut app CustomersApiLiteApp) add_contact(mut ctx RequestContext)
 
         ctx.res.set_status(.created)
     } else if method == .head {
+        // Simply respond with the HTTP 200 OK status code.
     } else {
         ctx.res.header.add(.allow, h.hdr_allow_2)
         ctx.res.set_status(.method_not_allowed)
@@ -224,11 +229,23 @@ pub fn (mut app CustomersApiLiteApp) add_contact(mut ctx RequestContext)
 // @returns The `Result` struct with a specific HTTP status code provided,
 //          containing profile details for a given customer
 //          (in the response body in JSON representation).
-@['/v1/customers/:customer_id']
+@['/v1/customers/:customer_id'; get; head;
+    put; post; patch; delete; options; trace]
 pub fn (mut app CustomersApiLiteApp) get_customer(mut ctx RequestContext,
     customer_id string) veb.Result {
 
-    c.get_customer_(app.dbg, mut app.l)
+    method := ctx.req.method
+
+    h.dbg_(app.dbg, mut app.l, h.o_bracket + method.str() + h.c_bracket)
+
+    if (method == .get) || (method == .head) {
+        c.get_customer_(app.dbg, mut app.l)
+    } else {
+        ctx.res.header.add(.allow, h.hdr_allow_3)
+        ctx.res.set_status(.method_not_allowed)
+
+        return ctx.text(h.new_line)
+    }
 
     logger := c.common_ctrl_hlpr_(app.dbg)
 
@@ -247,11 +264,23 @@ pub fn (mut app CustomersApiLiteApp) get_customer(mut ctx RequestContext,
 //          and the response body in JSON representation,
 //          containing a list of all contacts associated with a given customer.
 //          May return client or server error depending on incoming request.
-@['/v1/customers/:customer_id/contacts']
+@['/v1/customers/:customer_id/contacts'; get; head;
+    put; post; patch; delete; options; trace]
 pub fn (mut app CustomersApiLiteApp) list_contacts(mut ctx RequestContext,
     customer_id string) veb.Result {
 
-    c.list_contacts_(app.dbg, mut app.l)
+    method := ctx.req.method
+
+    h.dbg_(app.dbg, mut app.l, h.o_bracket + method.str() + h.c_bracket)
+
+    if (method == .get) || (method == .head) {
+        c.list_contacts_(app.dbg, mut app.l)
+    } else {
+        ctx.res.header.add(.allow, h.hdr_allow_3)
+        ctx.res.set_status(.method_not_allowed)
+
+        return ctx.text(h.new_line)
+    }
 
     logger := c.common_ctrl_hlpr_(app.dbg)
 
@@ -274,13 +303,25 @@ pub fn (mut app CustomersApiLiteApp) list_contacts(mut ctx RequestContext,
 //          containing a list of all contacts of a given type
 //          associated with a given customer.
 //          May return client or server error depending on incoming request.
-@['/v1/customers/:customer_id/contacts/:contact_type']
+@['/v1/customers/:customer_id/contacts/:contact_type'; get; head;
+    put; post; patch; delete; options; trace]
 pub fn (mut app CustomersApiLiteApp) list_contacts_by_type(
     mut ctx          RequestContext,
         customer_id  string,
         contact_type string) veb.Result {
 
-    c.list_contacts_by_type_(app.dbg, mut app.l)
+    method := ctx.req.method
+
+    h.dbg_(app.dbg, mut app.l, h.o_bracket + method.str() + h.c_bracket)
+
+    if (method == .get) || (method == .head) {
+        c.list_contacts_by_type_(app.dbg, mut app.l)
+    } else {
+        ctx.res.header.add(.allow, h.hdr_allow_3)
+        ctx.res.set_status(.method_not_allowed)
+
+        return ctx.text(h.new_line)
+    }
 
     logger := c.common_ctrl_hlpr_(app.dbg)
 

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -215,25 +215,6 @@ pub fn (mut app CustomersApiLiteApp) add_contact(mut ctx RequestContext)
     return ctx.json(logger)
 }
 
-// list_customers The `GET /v1/customers` endpoint.
-//
-// Retrieves from the database and lists all customer profiles.
-//
-// @returns The `Result` struct with the `200 OK` HTTP status code
-//          and the response body in JSON representation,
-//          containing a list of all customer profiles.
-//          May return client or server error depending on incoming request.
-/* @['/v1/customers']
-pub fn (mut app CustomersApiLiteApp) list_customers(mut ctx RequestContext)
-    veb.Result {
-
-    c.list_customers_(app.dbg, mut app.l)
-
-    logger := c.common_ctrl_hlpr_(app.dbg)
-
-    return ctx.json(logger)
-}*/
-
 // get_customer The `GET /v1/customers/{customer_id}` endpoint.
 //
 // Retrieves profile details for a given customer from the database.

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-core.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.12
+ * Customers API Lite microservice prototype (V port). Version 0.0.20
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -1,7 +1,7 @@
 /*
  * src/api-lite-helper.v
  * ============================================================================
- * Customers API Lite microservice prototype (V port). Version 0.0.12
+ * Customers API Lite microservice prototype (V port). Version 0.0.20
  * ============================================================================
  * A daemon written in V (vlang/veb), designed and intended to be run
  * as a microservice, implementing a special Customers API prototype

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -22,10 +22,12 @@ import os
 import vseryakov.syslog as s
 
 // Helper constants.
-pub const exit_failure =   1 //    Failing exit status.
-pub const exit_success =   0 // Successful exit status.
-pub const o_bracket    = '['
-pub const c_bracket    = ']'
+pub const exit_failure =    1 //    Failing exit status.
+pub const exit_success =    0 // Successful exit status.
+pub const slash        =  '/'
+pub const o_bracket    =  '['
+pub const c_bracket    =  ']'
+pub const new_line     = '\n'
 
 // Common error messages.
 const err_port_valid_must_be_positive_int
@@ -67,6 +69,18 @@ pub const log_enabled_ = 'logger.debug.enabled'
 pub const log_dir_ = './log_/'
 pub const logfile_ = 'customers-api-lite.log'
 pub const logtime_ = '[YYYY-MM-DD][HH:mm:ss]'
+
+// REST URI path-related constants.
+pub const rest_version  = 'v1'
+pub const rest_prefix   = 'customers'
+pub const rest_contacts = 'contacts'
+pub const phone         = 'phone'
+pub const email         = 'email'
+
+// HTTP response-related constants.
+pub const hdr_allow_1 = 'PUT, GET, HEAD'
+pub const hdr_allow_2 = 'PUT, HEAD'
+pub const hdr_allow_3 = 'GET, HEAD'
 
 // get_settings_ Helper function. Used to get the daemon settings.
 pub fn get_settings_() toml.Doc {

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,7 @@
 Module {
     name:         'api-lited'
     description:  'A daemon written in V (vlang/veb), designed and intended to be run as a microservice, implementing a special Customers API prototype with a smart yet simplified data scheme.'
-    version:      '0.0.12'
+    version:      '0.0.20'
     license:      'MIT'
     dependencies: []
 }


### PR DESCRIPTION
- Transforming the `PUT /v1/customers` endpoint to the compound `PUT /v1/customers` / `GET /v1/customers` endpoint.
- Handling properly **HTTP PUT**, **GET**, **HEAD** methods only:
- Responding with the `HTTP 201 Created` status code for **PUT** requests.
- Responding with the `HTTP 200 OK` status code for **GET** and **HEAD** requests.
- Responding with the `HTTP 405 Method Not Allowed` status code _for other methods (not allowed ones)_.
- Adding REST URI path-related constants, HTTP response-related constants, and other helper constants.
- Bumping version number to **0.0.20**.