### PR TITLE
Retrieve all contacts associated with a given customer from the database using the corresponding controller function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,24 @@ $ curl -v http://localhost:8765/v1/customers/2
 
 5. **List contacts for a given customer**
 
-**TBD** :cd:
+```
+$ curl -v http://localhost:8765/v1/customers/2/contacts
+...
+> GET /v1/customers/2/contacts HTTP/1.1
+...
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< Content-Length: 190
+< Server: veb
+...
+[{"contact":"+35760X123456"},{"contact":"+35760Y1234578"},{"contact":"+35790Z12345890"},{"contact":"nn@example.org"},{"contact":"nnumbat@example.com"},{"contact":"noble.numbat@example.com"}]
+```
 
 6. **List contacts of a given type for a given customer**
 
 **TBD** :cd:
+
+> ^ The given names in customer accounts and in email contacts (in samples above) are for demonstrational purposes only. They have nothing common WRT any actual, ever really encountered names elsewhere.
 
 ---
 

--- a/src/api-lite-controller.v
+++ b/src/api-lite-controller.v
@@ -34,7 +34,7 @@ pub struct Customer {
 
 // Contact The struct defining the Contact entity.
 pub struct Contact {
-    // TODO: Declare fields.
+    contact string
 }
 
 // common_ctrl_hlpr_ Common controller helper function.
@@ -148,9 +148,23 @@ pub fn get_customer(dbg bool, mut l log.Log, cnx sqlite.DB, customer_id string)
 pub fn get_contacts(dbg bool, mut l log.Log, cnx sqlite.DB, customer_id string
     ) []Contact {
 
-    h.dbg_(dbg, mut l, h.o_bracket + '${customer_id}' + h.c_bracket)
+    h.dbg_(dbg, mut l, h.cust_id + h.equals + customer_id)
 
-    conts := []Contact{}
+    contacts := cnx.exec_param_many(m.sql_get_all_contacts, [
+        customer_id, // <== For retrieving phones.
+        customer_id  // <== For retrieving emails.
+    ]) or { panic(err) }
+
+    mut conts := []Contact{}
+
+    for contact in contacts {
+        conts << Contact{
+            contact: contact.vals[0]
+        }
+    }
+
+    h.dbg_(dbg, mut l, h.o_bracket + conts[0].contact // getContact()
+                     + h.c_bracket)
 
     return conts
 }

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -289,17 +289,17 @@ pub fn (mut app CustomersApiLiteApp) list_contacts(mut ctx RequestContext,
     h.dbg_(app.dbg, mut app.l, h.o_bracket + method.str() + h.c_bracket)
 
     if (method == .get) || (method == .head) {
-        c.get_contacts(app.dbg, mut app.l, app.cnx, customer_id)
+        // Retrieving all contacts associated with a given customer
+        // from the database.
+        contacts := c.get_contacts(app.dbg, mut app.l, app.cnx, customer_id)
+
+        return ctx.json(contacts)
     } else {
         ctx.res.header.add(.allow, h.hdr_allow_3)
         ctx.res.set_status(.method_not_allowed)
 
         return ctx.text(h.new_line)
     }
-
-    logger := c.common_ctrl_hlpr_(app.dbg)
-
-    return ctx.json(logger)
 }
 
 // list_contacts_by_type The


### PR DESCRIPTION
- Implementing the controller function `get_contacts()` that _retrieves all contacts associated with a given customer from the database_.
- Implementing the `GET /v1/customers/{customer_id}/contacts` endpoint completely.
- Exposing a command-line snippet of accessing the **"List contacts for a given customer"** endpoint with actual return values.