### PR TITLE
Retrieve all contacts of a given type associated with a given customer from the database using the corresponding controller function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,33 @@ $ curl -v http://localhost:8765/v1/customers/2/contacts
 
 6. **List contacts of a given type for a given customer**
 
-**TBD** :cd:
+```
+$ curl -v http://localhost:8765/v1/customers/2/contacts/phone
+...
+> GET /v1/customers/2/contacts/phone HTTP/1.1
+...
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< Content-Length: 88
+< Server: veb
+...
+[{"contact":"+35760X123456"},{"contact":"+35760Y1234578"},{"contact":"+35790Z12345890"}]
+```
+
+Or list **email** contacts:
+
+```
+$ curl -v http://localhost:8765/v1/customers/2/contacts/email
+...
+> GET /v1/customers/2/contacts/email HTTP/1.1
+...
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< Content-Length: 103
+< Server: veb
+...
+[{"contact":"noble.numbat@example.com"},{"contact":"nnumbat@example.com"},{"contact":"nn@example.org"}]
+```
 
 > ^ The given names in customer accounts and in email contacts (in samples above) are for demonstrational purposes only. They have nothing common WRT any actual, ever really encountered names elsewhere.
 

--- a/src/api-lite-controller.v
+++ b/src/api-lite-controller.v
@@ -182,11 +182,32 @@ pub fn get_contacts_by_type(dbg bool, mut l log.Log, cnx sqlite.DB,
     customer_id  string,
     contact_type string) []Contact {
 
-    h.dbg_(dbg, mut l, h.o_bracket + '${customer_id}'
-                     + h.v_bar     + '${contact_type}'
-                     + h.c_bracket)
+    h.dbg_(dbg, mut l, h.cust_id   + h.equals + customer_id + h.space + h.v_bar
+           + h.space + h.cont_type + h.equals + contact_type)
 
-    conts := []Contact{}
+    mut sql_query := m.sql_get_contacts_by_type[2]
+
+    if (contact_type == h.phone)
+        || (contact_type == h.phone.to_upper_ascii()) {
+
+        sql_query = m.sql_get_contacts_by_type[0]
+    } else if (contact_type == h.email)
+        || (contact_type == h.email.to_upper_ascii()) {
+
+        sql_query = m.sql_get_contacts_by_type[1]
+    }
+
+    contacts  := cnx.exec_param(sql_query, customer_id) or { panic(err) }
+    mut conts := []Contact{}
+
+    for contact in contacts {
+        conts << Contact{
+            contact: contact.vals[0]
+        }
+    }
+
+    h.dbg_(dbg, mut l, h.o_bracket + conts[0].contact // getContact()
+                     + h.c_bracket)
 
     return conts
 }

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -337,18 +337,18 @@ pub fn (mut app CustomersApiLiteApp) list_contacts_by_type(
     h.dbg_(app.dbg, mut app.l, h.o_bracket + method.str() + h.c_bracket)
 
     if (method == .get) || (method == .head) {
-        c.get_contacts_by_type(app.dbg, mut app.l, app.cnx,
+        // Retrieving all contacts of a given type associated
+        // with a given customer from the database.
+        contacts := c.get_contacts_by_type(app.dbg, mut app.l, app.cnx,
             customer_id, contact_type)
+
+        return ctx.json(contacts)
     } else {
         ctx.res.header.add(.allow, h.hdr_allow_3)
         ctx.res.set_status(.method_not_allowed)
 
         return ctx.text(h.new_line)
     }
-
-    logger := c.common_ctrl_hlpr_(app.dbg)
-
-    return ctx.json(logger)
 }
 
 // vim:set nu et ts=4 sw=4:

--- a/src/api-lite-core.v
+++ b/src/api-lite-core.v
@@ -134,6 +134,8 @@ fn main() {
 //
 // `{customer_name}` is a name assigned to a newly created customer.
 //
+// @param `ctx` The struct containing an HTTP request/response pair.
+//
 // @returns The `Result` struct with the `201 Created` HTTP status code,
 //          the `Location` response header (among others), and the response
 //          body in JSON representation, containing profile details
@@ -198,6 +200,8 @@ pub fn (mut app CustomersApiLiteApp) add_list_customers(mut ctx RequestContext)
 //
 // `{customer_contact}` is a newly created contact (phone or email).
 //
+// @param `ctx` The struct containing an HTTP request/response pair.
+//
 // @returns The `Result` struct with the `201 Created` HTTP status code,
 //          the `Location` response header (among others), and the response
 //          body in JSON representation, containing details of a newly created
@@ -240,6 +244,7 @@ pub fn (mut app CustomersApiLiteApp) add_contact(mut ctx RequestContext)
 //
 // Retrieves profile details for a given customer from the database.
 //
+// @param `ctx`         The struct containing an HTTP request/response pair.
 // @param `customer_id` The customer ID used to retrieve customer profile data.
 //
 // @returns The `Result` struct with a specific HTTP status code provided,
@@ -272,6 +277,7 @@ pub fn (mut app CustomersApiLiteApp) get_customer(mut ctx RequestContext,
 // Retrieves from the database and lists all contacts
 // associated with a given customer.
 //
+// @param `ctx`         The struct containing an HTTP request/response pair.
 // @param `customer_id` The customer ID used to retrieve contacts
 //                      which belong to this customer.
 //
@@ -308,6 +314,7 @@ pub fn (mut app CustomersApiLiteApp) list_contacts(mut ctx RequestContext,
 // Retrieves from the database and lists all contacts of a given type
 // associated with a given customer.
 //
+// @param `ctx`          The struct containing an HTTP request/response pair.
 // @param `customer_id`  The customer ID used to retrieve contacts
 //                       which belong to this customer.
 // @param `contact_type` The particular type of contacts to retrieve

--- a/src/api-lite-helper.v
+++ b/src/api-lite-helper.v
@@ -24,6 +24,7 @@ import vseryakov.syslog as s
 // Helper constants.
 pub const exit_failure =    1 //    Failing exit status.
 pub const exit_success =    0 // Successful exit status.
+pub const space        =  ' '
 pub const slash        =  '/'
 pub const equals       =  '='
 pub const v_bar        =  '|'


### PR DESCRIPTION
- Implementing the controller function `get_contacts_by_type()` that _retrieves all contacts of a given type associated with a given customer from the database_.
- Implementing the `GET /v1/customers/{customer_id}/contacts/{contact_type}` endpoint completely.
- Exposing a command-line snippet of accessing the **"List contacts of a given type for a given customer"** endpoint with actual return values.